### PR TITLE
SIR-2180 Delete from limit storage by partitionkey/rowkey instead of entity.

### DIFF
--- a/scripts/Lykke.Service.Tier.LimitUpdater/Program.cs
+++ b/scripts/Lykke.Service.Tier.LimitUpdater/Program.cs
@@ -133,7 +133,7 @@ namespace Lykke.Service.Tier.LimitUpdater
             var deleteCounter = 0;
             foreach (var limitEntity in selectedForDeletion)
             {
-                await limitStorage.DeleteAsync(limitEntity);
+                await limitStorage.DeleteAsync(limitEntity.PartitionKey, limitEntity.RowKey);
                 deleteCounter++;
                 logger.Info($"{deleteCounter} of {selectedForDeletion.Count} deleted");
             }


### PR DESCRIPTION
Looks like, while deleting by entity library uses Etag as concurrency stamp to enforce optimistic concurrency, which leads to `Microsoft.WindowsAzure.Storage.StorageException: Precondition Failed`